### PR TITLE
fix: corrigir erros de funcionalidade da landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,20 +5,20 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>GS Aprova | Aulas de Matemática e Correção de Redação para ENEM e Fuvest</title>
     <meta name="description" content="Aulas práticas de Matemática e correções detalhadas de Redação para ENEM e Fuvest. Estude online ou presencial. Fale agora pelo WhatsApp.">
-    
+
     <!-- OpenGraph tags -->
     <meta property="og:title" content="GS Aprova | Aulas de Matemática e Correção de Redação para ENEM e Fuvest">
     <meta property="og:description" content="Aulas práticas de Matemática e correções detalhadas de Redação para ENEM e Fuvest. Estude online ou presencial. Fale agora pelo WhatsApp.">
     <meta property="og:image" content="file_00000000e6c0622fb7287c2da1af5d94.png">
     <meta property="og:type" content="website">
-    
+
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>
     <!-- CTA Sticky -->
     <div class="cta-sticky" id="ctaSticky">
-        <a href="https://wa.me/5511974969036?text=Oi%2C%20quero%20saber%20mais%20sobre%20Matem%C3%A1tica%20ou%20Reda%C3%A7%C3%A3o" 
-           class="cta-button" 
+        <a href="https://wa.me/5511974969036?text=Oi%2C%20quero%20saber%20mais%20sobre%20Matem%C3%A1tica%20ou%20Reda%C3%A7%C3%A3o"
+           class="cta-button"
            onclick="trackEvent('cta_whatsapp_click', 'sticky_cta')">
             💬 WhatsApp
         </a>
@@ -31,10 +31,10 @@
                 <img src="file_00000000e6c0622fb7287c2da1af5d94.png" alt="GS Aprova" class="logo">
                 <h1>GS Aprova | Aulas de Matemática e Correção de Redação</h1>
                 <p class="subtitle">Preparação objetiva para ENEM e Fuvest — online ou presencial (SP)</p>
-                <a href="https://wa.me/5511974969036?text=Oi%2C%20quero%20saber%20mais%20sobre%20Matem%C3%A1tica%20ou%20Reda%C3%A7%C3%A3o" 
-                   class="cta-button cta-prima" 
+                <a href="https://wa.me/5511974969036?text=Oi%2C%20quero%20saber%20mais%20sobre%20Matem%C3%A1tica%20ou%20Reda%C3%A7%C3%A3o"
+                   class="cta-button cta-primary"
                    onclick="trackEvent('cta_whatsapp_click', 'hero_cta')">
-                    <img src="whatsapp-icon.png" alt="WhatsApp" style="width: 24px; height: 24px; vertical-align: middle; margin-right: 8px;"> Falar no WhatsApp agora
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="white" width="24" height="24" style="vertical-align:middle;margin-right:8px;"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347z"/><path d="M12 0C5.373 0 0 5.373 0 12c0 2.127.558 4.123 1.528 5.855L.057 23.882a.5.5 0 0 0 .606.65l6.288-1.651A11.942 11.942 0 0 0 12 24c6.627 0 12-5.373 12-12S18.627 0 12 0zm0 22c-1.925 0-3.72-.524-5.262-1.434l-.371-.215-3.814 1.002.973-3.706-.236-.382A9.956 9.956 0 0 1 2 12C2 6.477 6.477 2 12 2s10 4.477 10 10-4.477 10-10 10z"/></svg> Falar no WhatsApp agora
                 </a>
             </div>
         </div>
@@ -54,7 +54,7 @@
                             <div class="card-content">
                                 <h4>Aula Avulsa (1h)</h4>
                                 <p class="price">R$ 70</p>
-                                <a href="https://wa.me/5511974969036?text=Quero%20aula%20avulsa%20de%20Matem%C3%A1tica" 
+                                <a href="https://wa.me/5511974969036?text=Quero%20aula%20avulsa%20de%20Matem%C3%A1tica"
                                    class="cta-button"
                                    onclick="trackEvent('cta_whatsapp_click', 'Matemática Avulsa')">
                                     Contratar agora
@@ -66,7 +66,7 @@
                             <div class="card-content">
                                 <h4>Pacote 4 aulas</h4>
                                 <p class="price">R$ 250</p>
-                                <a href="https://wa.me/5511974969036?text=Quero%20o%20pacote%204%20aulas%20de%20Matem%C3%A1tica" 
+                                <a href="https://wa.me/5511974969036?text=Quero%20o%20pacote%204%20aulas%20de%20Matem%C3%A1tica"
                                    class="cta-button"
                                    onclick="trackEvent('cta_whatsapp_click', 'Matemática Pacote')">
                                     Contratar agora
@@ -85,7 +85,7 @@
                             <div class="card-content">
                                 <h4>Correção Avulsa</h4>
                                 <p class="price">R$ 70</p>
-                                <a href="https://wa.me/5511974969036?text=Quero%20uma%20corre%C3%A7%C3%A3o%20avulsa%20de%20Reda%C3%A7%C3%A3o" 
+                                <a href="https://wa.me/5511974969036?text=Quero%20uma%20corre%C3%A7%C3%A3o%20avulsa%20de%20Reda%C3%A7%C3%A3o"
                                    class="cta-button"
                                    onclick="trackEvent('cta_whatsapp_click', 'Redação Avulsa')">
                                     Contratar agora
@@ -97,7 +97,7 @@
                             <div class="card-content">
                                 <h4>Pacote 5 correções + 2h orientação</h4>
                                 <p class="price">R$ 350</p>
-                                <a href="https://wa.me/5511974969036?text=Quero%20o%20pacote%205%20corre%C3%A7%C3%B5es%20de%20Reda%C3%A7%C3%A3o" 
+                                <a href="https://wa.me/5511974969036?text=Quero%20o%20pacote%205%20corre%C3%A7%C3%B5es%20de%20Reda%C3%A7%C3%A3o"
                                    class="cta-button"
                                    onclick="trackEvent('cta_whatsapp_click', 'Redação Pacote')">
                                     Contratar agora
@@ -165,7 +165,7 @@
                         <p>Aceitamos pagamento via Pix (desconto de 5%) e cartão de crédito em até 3x sem juros. O pagamento é feito antes do início das aulas ou correções.</p>
                     </div>
                 </div>
-                
+
                 <div class="faq-item">
                     <div class="faq-question">
                         <h3>As aulas são online ou presenciais?</h3>
@@ -175,7 +175,7 @@
                         <p>Oferecemos ambas as modalidades! As aulas online são via Google Meet ou Zoom, e as presenciais são realizadas em São Paulo (região a combinar).</p>
                     </div>
                 </div>
-                
+
                 <div class="faq-item">
                     <div class="faq-question">
                         <h3>Quanto tempo demora para receber a correção da redação?</h3>
@@ -185,7 +185,7 @@
                         <p>As correções são entregues em até 2 dias úteis após o envio. Você recebe feedback detalhado com pontuação por competência e sugestões de melhoria.</p>
                     </div>
                 </div>
-                
+
                 <div class="faq-item">
                     <div class="faq-question">
                         <h3>Posso cancelar ou remarcar uma aula?</h3>
@@ -195,7 +195,7 @@
                         <p>Sim! Você pode remarcar com até 24h de antecedência sem custos. Para cancelamentos, consulte nossa política de reembolso.</p>
                     </div>
                 </div>
-                
+
                 <div class="faq-item">
                     <div class="faq-question">
                         <h3>Vocês têm experiência com ENEM e Fuvest?</h3>
@@ -205,436 +205,7 @@
                         <p>Sim! Nossa equipe tem mais de 5 anos de experiência preparando alunos especificamente para ENEM e Fuvest, com foco nos conteúdos que mais caem.</p>
                     </div>
                 </div>
-                
-                <div class="faq-item">
-                    <div class="faq-question">
-                        <h3>Oferecem material de apoio?</h3>
-                        <span class="faq-toggle">+</span>
-                    </div>
-                    <div class="faq-answer">
-                        <p>Sim! Fornecemos listas de exercícios, resumos teóricos e modelos de redação. Todo material é focado nos padrões ENEM e Fuvest.</p>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </section>
 
-    <!-- Garantias -->
-    <section class="guarantees">
-        <div class="container">
-            <h2>Nossas Garantias</h2>
-            <div class="guarantees-list">
-                <div class="guarantee-item">
-                    <span class="check">✔️</span>
-                    <span>Pagamento fácil via Pix/Cartão</span>
-                </div>
-                <div class="guarantee-item">
-                    <span class="check">✔️</span>
-                    <span>Atendimento rápido</span>
-                </div>
-                <div class="guarantee-item">
-                    <span class="check">✔️</span>
-                    <span>Experiência em preparação para ENEM/Fuvest</span>
-                </div>
-            </div>
-        </div>
-    </section>
-
-    <!-- Rodapé -->
-    <footer class="footer">
-        <div class="container">
-            <p>&copy; 2025 GS Aprova | Contato: <a href="https://wa.me/5511974969036">WhatsApp</a> | <a href="#">Instagram</a></p>
-        </div>
-    </footer>
-
-    <script src="script.js"></script>
-</body>
-</html>                    <img src="whatsapp-icon.png" alt="WhatsApp" style="width: 24px; height: 24px; vertical-align: middle; margin-right: 8px;"> Falar no WhatsApp agora
-                </a>
-            </div>
-        </div>
-    </header>
-
-    <!-- Cardápio de Serviços -->
-    <section class="services" id="services">
-        <div class="container">
-            <h2>Nossos Serviços</h2>
-            <div class="services-grid">
-                <!-- Matemática -->
-                <div class="service-category">
-                    <h3>📐 Matemática</h3>
-                    <div class="service-cards">
-                        <div class="service-card">
-                            <img src="file-BOyF5KlzW81yAAzWqlYGn8xl.png" alt="Matemática - Aula Avulsa">
-                            <div class="card-content">
-                                <h4>Aula Avulsa (1h)</h4>
-                                <p class="price">R$ 70</p>
-                                <a href="https://wa.me/5511974969036?text=Quero%20aula%20avulsa%20de%20Matem%C3%A1tica" 
-                                   class="cta-button"
-                                   onclick="trackEvent('cta_whatsapp_click', 'Matemática Avulsa')">
-                                    Contratar agora
-                                </a>
-                            </div>
-                        </div>
-                        <div class="service-card">
-                            <img src="file-0YQpCUux3vwXLsZa84igSG3q.png" alt="Matemática - Pacote 4 aulas">
-                            <div class="card-content">
-                                <h4>Pacote 4 aulas</h4>
-                                <p class="price">R$ 250</p>
-                                <a href="https://wa.me/5511974969036?text=Quero%20o%20pacote%204%20aulas%20de%20Matem%C3%A1tica" 
-                                   class="cta-button"
-                                   onclick="trackEvent('cta_whatsapp_click', 'Matemática Pacote')">
-                                    Contratar agora
-                                </a>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-
-                <!-- Redação -->
-                <div class="service-category">
-                    <h3>📝 Redação</h3>
-                    <div class="service-cards">
-                        <div class="service-card">
-                            <img src="file-LFlfNaMpRz7vW6sc71IkUvS7.png" alt="Redação - Correção Avulsa">
-                            <div class="card-content">
-                                <h4>Correção Avulsa</h4>
-                                <p class="price">R$ 70</p>
-                                <a href="https://wa.me/5511974969036?text=Quero%20uma%20corre%C3%A7%C3%A3o%20avulsa%20de%20Reda%C3%A7%C3%A3o" 
-                                   class="cta-button"
-                                   onclick="trackEvent('cta_whatsapp_click', 'Redação Avulsa')">
-                                    Contratar agora
-                                </a>
-                            </div>
-                        </div>
-                        <div class="service-card">
-                            <img src="file-fkdOqclAZAGdozP3aXsraV7j.png" alt="Redação - Pacote 5 correções + 2h orientação">
-                            <div class="card-content">
-                                <h4>Pacote 5 correções + 2h orientação</h4>
-                                <p class="price">R$ 350</p>
-                                <a href="https://wa.me/5511974969036?text=Quero%20o%20pacote%205%20corre%C3%A7%C3%B5es%20de%20Reda%C3%A7%C3%A3o" 
-                                   class="cta-button"
-                                   onclick="trackEvent('cta_whatsapp_click', 'Redação Pacote')">
-                                    Contratar agora
-                                </a>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </section>
-
-    <!-- Como Funciona -->
-    <section class="how-it-works">
-        <div class="container">
-            <h2>Como Funciona</h2>
-            <div class="steps">
-                <div class="step">
-                    <div class="step-number">1</div>
-                    <h3>Você chama no WhatsApp</h3>
-                    <p>Entre em contato conosco pelo WhatsApp para iniciar sua jornada de aprendizado</p>
-                </div>
-                <div class="step">
-                    <div class="step-number">2</div>
-                    <h3>Fazemos um diagnóstico rápido</h3>
-                    <p>Identificamos suas necessidades e pontos de melhoria para personalizar o ensino</p>
-                </div>
-                <div class="step">
-                    <div class="step-number">3</div>
-                    <h3>Aula ou correção em até 2 dias</h3>
-                    <p>Começamos imediatamente com aulas práticas ou correções detalhadas em até dois dias do envio</p>
-                </div>
-            </div>
-        </div>
-    </section>
-
-    <!-- Prova Social -->
-    <section class="testimonials">
-        <div class="container">
-            <h2>O que nossos alunos dizem</h2>
-            <div class="testimonials-grid">
-                <div class="testimonial">
-                    <p>"Consegui subir minha nota de Matemática em 3 simulados seguidos!"</p>
-                    <span class="author">— Aluno GS Aprova</span>
-                </div>
-                <div class="testimonial">
-                    <p>"Feedback de redação direto ao ponto. Cheguei no 920."</p>
-                    <span class="author">— Aluna GS Aprova</span>
-                </div>
-            </div>
-        </div>
-    </section>
-
-    <!-- FAQ Section -->
-    <section class="faq">
-        <div class="container">
-            <h2>Perguntas Frequentes</h2>
-            <div class="faq-list">
-                <div class="faq-item">
-                    <div class="faq-question">
-                        <h3>Como funciona o pagamento?</h3>
-                        <span class="faq-toggle">+</span>
-                    </div>
-                    <div class="faq-answer">
-                        <p>Aceitamos pagamento via Pix (desconto de 5%) e cartão de crédito em até 3x sem juros. O pagamento é feito antes do início das aulas ou correções.</p>
-                    </div>
-                </div>
-                
-                <div class="faq-item">
-                    <div class="faq-question">
-                        <h3>As aulas são online ou presenciais?</h3>
-                        <span class="faq-toggle">+</span>
-                    </div>
-                    <div class="faq-answer">
-                        <p>Oferecemos ambas as modalidades! As aulas online são via Google Meet ou Zoom, e as presenciais são realizadas em São Paulo (região a combinar).</p>
-                    </div>
-                </div>
-                
-                <div class="faq-item">
-                    <div class="faq-question">
-                        <h3>Quanto tempo demora para receber a correção da redação?</h3>
-                        <span class="faq-toggle">+</span>
-                    </div>
-                    <div class="faq-answer">
-                        <p>As correções são entregues em até 2 dias úteis após o envio. Você recebe feedback detalhado com pontuação por competência e sugestões de melhoria.</p>
-                    </div>
-                </div>
-                
-                <div class="faq-item">
-                    <div class="faq-question">
-                        <h3>Posso cancelar ou remarcar uma aula?</h3>
-                        <span class="faq-toggle">+</span>
-                    </div>
-                    <div class="faq-answer">
-                        <p>Sim! Você pode remarcar com até 24h de antecedência sem custos. Para cancelamentos, consulte nossa política de reembolso.</p>
-                    </div>
-                </div>
-                
-                <div class="faq-item">
-                    <div class="faq-question">
-                        <h3>Vocês têm experiência com ENEM e Fuvest?</h3>
-                        <span class="faq-toggle">+</span>
-                    </div>
-                    <div class="faq-answer">
-                        <p>Sim! Nossa equipe tem mais de 5 anos de experiência preparando alunos especificamente para ENEM e Fuvest, com foco nos conteúdos que mais caem.</p>
-                    </div>
-                </div>
-                
-                <div class="faq-item">
-                    <div class="faq-question">
-                        <h3>Oferecem material de apoio?</h3>
-                        <span class="faq-toggle">+</span>
-                    </div>
-                    <div class="faq-answer">
-                        <p>Sim! Fornecemos listas de exercícios, resumos teóricos e modelos de redação. Todo material é focado nos padrões ENEM e Fuvest.</p>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </section>
-
-    <!-- Garantias -->
-    <section class="guarantees">
-        <div class="container">
-            <h2>Nossas Garantias</h2>
-            <div class="guarantees-list">
-                <div class="guarantee-item">
-                    <span class="check">✔️</span>
-                    <span>Pagamento fácil via Pix/Cartão</span>
-                </div>
-                <div class="guarantee-item">
-                    <span class="check">✔️</span>
-                    <span>Atendimento rápido</span>
-                </div>
-                <div class="guarantee-item">
-                    <span class="check">✔️</span>
-                    <span>Experiência em preparação para ENEM/Fuvest</span>
-                </div>
-            </div>
-        </div>
-    </section>
-
-    <!-- Rodapé -->
-    <footer class="footer">
-        <div class="container">
-            <p>&copy; 2025 GS Aprova | Contato: <a href="https://wa.me/5511974969036">WhatsApp</a> | <a href="#">Instagram</a></p>
-        </div>
-    </footer>
-
-    <script src="script.js"></script>
-</body>
-</html>                </a>
-            </div>
-        </div>
-    </header>
-
-    <!-- Cardápio de Serviços -->
-    <section class="services" id="services">
-        <div class="container">
-            <h2>Nossos Serviços</h2>
-            <div class="services-grid">
-                <!-- Matemática -->
-                <div class="service-category">
-                    <h3>📐 Matemática</h3>
-                    <div class="service-cards">
-                        <div class="service-card">
-                            <img src="matematica-avulsa.png" alt="Matemática - Aula Avulsa">
-                            <div class="card-content">
-                                <h4>Aula Avulsa (1h)</h4>
-                                <p class="price">R$ 70</p>
-                                <a href="https://wa.me/5511974969036?text=Quero%20aula%20avulsa%20de%20Matem%C3%A1tica" 
-                                   class="cta-button"
-                                   onclick="trackEvent('cta_whatsapp_click', 'Matemática Avulsa')">
-                                    Contratar agora
-                                </a>
-                            </div>
-                        </div>
-                        <div class="service-card">
-                            <img src="matematica-pacote.png" alt="Matemática - Pacote 4 aulas">
-                            <div class="card-content">
-                                <h4>Pacote 4 aulas</h4>
-                                <p class="price">R$ 250</p>
-                                <a href="https://wa.me/5511974969036?text=Quero%20o%20pacote%204%20aulas%20de%20Matem%C3%A1tica" 
-                                   class="cta-button"
-                                   onclick="trackEvent('cta_whatsapp_click', 'Matemática Pacote')">
-                                    Contratar agora
-                                </a>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-
-                <!-- Redação -->
-                <div class="service-category">
-                    <h3>📝 Redação</h3>
-                    <div class="service-cards">
-                        <div class="service-card">
-                            <img src="redacao-avulsa.png" alt="Redação - Correção Avulsa">
-                            <div class="card-content">
-                                <h4>Correção Avulsa</h4>
-                                <p class="price">R$ 70</p>
-                                <a href="https://wa.me/5511974969036?text=Quero%20uma%20corre%C3%A7%C3%A3o%20avulsa%20de%20Reda%C3%A7%C3%A3o" 
-                                   class="cta-button"
-                                   onclick="trackEvent('cta_whatsapp_click', 'Redação Avulsa')">
-                                    Contratar agora
-                                </a>
-                            </div>
-                        </div>
-                        <div class="service-card">
-                            <img src="redacao-pacote.png" alt="Redação - Pacote 5 correções + 2h orientação">
-                            <div class="card-content">
-                                <h4>Pacote 5 correções + 2h orientação</h4>
-                                <p class="price">R$ 350</p>
-                                <a href="https://wa.me/5511974969036?text=Quero%20o%20pacote%205%20corre%C3%A7%C3%B5es%20de%20Reda%C3%A7%C3%A3o" 
-                                   class="cta-button"
-                                   onclick="trackEvent('cta_whatsapp_click', 'Redação Pacote')">
-                                    Contratar agora
-                                </a>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </section>
-
-    <!-- Como Funciona -->
-    <section class="how-it-works">
-        <div class="container">
-            <h2>Como Funciona</h2>
-            <div class="steps">
-                <div class="step">
-                    <div class="step-number">1</div>
-                    <h3>Você chama no WhatsApp</h3>
-                    <p>Entre em contato conosco pelo WhatsApp para iniciar sua jornada de aprendizado</p>
-                </div>
-                <div class="step">
-                    <div class="step-number">2</div>
-                    <h3>Fazemos um diagnóstico rápido</h3>
-                    <p>Identificamos suas necessidades e pontos de melhoria para personalizar o ensino</p>
-                </div>
-                <div class="step">
-                    <div class="step-number">3</div>
-                    <h3>Aula ou correção em até 2 dias</h3>
-                    <p>Começamos imediatamente com aulas práticas ou correções detalhadas em até dois dias do envio</p>
-                </div>
-            </div>
-        </div>
-    </section>
-
-    <!-- Prova Social -->
-    <section class="testimonials">
-        <div class="container">
-            <h2>O que nossos alunos dizem</h2>
-            <div class="testimonials-grid">
-                <div class="testimonial">
-                    <p>"Consegui subir minha nota de Matemática em 3 simulados seguidos!"</p>
-                    <span class="author">— Aluno GS Aprova</span>
-                </div>
-                <div class="testimonial">
-                    <p>"Feedback de redação direto ao ponto. Cheguei no 920."</p>
-                    <span class="author">— Aluna GS Aprova</span>
-                </div>
-            </div>
-        </div>
-    </section>
-
-    <!-- FAQ Section -->
-    <section class="faq">
-        <div class="container">
-            <h2>Perguntas Frequentes</h2>
-            <div class="faq-list">
-                <div class="faq-item">
-                    <div class="faq-question">
-                        <h3>Como funciona o pagamento?</h3>
-                        <span class="faq-toggle">+</span>
-                    </div>
-                    <div class="faq-answer">
-                        <p>Aceitamos pagamento via Pix (desconto de 5%) e cartão de crédito em até 3x sem juros. O pagamento é feito antes do início das aulas ou correções.</p>
-                    </div>
-                </div>
-                
-                <div class="faq-item">
-                    <div class="faq-question">
-                        <h3>As aulas são online ou presenciais?</h3>
-                        <span class="faq-toggle">+</span>
-                    </div>
-                    <div class="faq-answer">
-                        <p>Oferecemos ambas as modalidades! As aulas online são via Google Meet ou Zoom, e as presenciais são realizadas em São Paulo (região a combinar).</p>
-                    </div>
-                </div>
-                
-                <div class="faq-item">
-                    <div class="faq-question">
-                        <h3>Quanto tempo demora para receber a correção da redação?</h3>
-                        <span class="faq-toggle">+</span>
-                    </div>
-                    <div class="faq-answer">
-                        <p>As correções são entregues em até 2 dias úteis após o envio. Você recebe feedback detalhado com pontuação por competência e sugestões de melhoria.</p>
-                    </div>
-                </div>
-                
-                <div class="faq-item">
-                    <div class="faq-question">
-                        <h3>Posso cancelar ou remarcar uma aula?</h3>
-                        <span class="faq-toggle">+</span>
-                    </div>
-                    <div class="faq-answer">
-                        <p>Sim! Você pode remarcar com até 24h de antecedência sem custos. Para cancelamentos, consulte nossa política de reembolso.</p>
-                    </div>
-                </div>
-                
-                <div class="faq-item">
-                    <div class="faq-question">
-                        <h3>Vocês têm experiência com ENEM e Fuvest?</h3>
-                        <span class="faq-toggle">+</span>
-                    </div>
-                    <div class="faq-answer">
-                        <p>Sim! Nossa equipe tem mais de 5 anos de experiência preparando alunos especificamente para ENEM e Fuvest, com foco nos conteúdos que mais caem.</p>
-                    </div>
-                </div>
-                
                 <div class="faq-item">
                     <div class="faq-question">
                         <h3>Oferecem material de apoio?</h3>
@@ -679,4 +250,3 @@
     <script src="script.js"></script>
 </body>
 </html>
-

--- a/script.js
+++ b/script.js
@@ -26,14 +26,6 @@ function trackEvent(eventName, planName) {
         });
     }
     
-    // Log para debug
-    console.log('Event tracked:', {
-        event: eventName,
-        plan_name: planName,
-        utm_source: utmSource,
-        utm_medium: utmMedium,
-        utm_campaign: utmCampaign
-    });
 }
 
 // Controle do CTA sticky

--- a/styles.css
+++ b/styles.css
@@ -28,6 +28,8 @@ body {
     right: 20px;
     z-index: 1000;
     animation: pulse 2s infinite;
+    opacity: 0;
+    visibility: hidden;
 }
 
 .cta-sticky .cta-button {


### PR DESCRIPTION
- Remove ~430 linhas de HTML duplicado/corrompido após o </html> que causava
  boxes fantasmas ao inicializar a página no browser
- Corrige typo de classe CSS cta-prima → cta-primary no botão hero
- Substitui referência a whatsapp-icon.png (inexistente) por SVG inline
- Oculta cta-sticky via CSS para eliminar flash antes do JavaScript carregar
- Remove console.log de debug exposto em produção

https://claude.ai/code/session_01H34q8JmpTQX7R7MQ2TrP6k